### PR TITLE
Upgrade LangChaing4J dependency because of vulnerability in a dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ log4j2 = "2.24.3"
 gson = "2.12.1"
 
 # Interface for LLM management system
-langchain4j = "1.0.0-beta1"
+langchain4j = "1.0.1-beta6"
 
 # Gradle plugin for making FAT Jars
 shadow = "8.3.6"

--- a/src/main/java/com/github/koen_mulder/file_rename_helper/suggestions/OllamaSuggestionService.java
+++ b/src/main/java/com/github/koen_mulder/file_rename_helper/suggestions/OllamaSuggestionService.java
@@ -10,7 +10,7 @@ import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.loader.FileSystemDocumentLoader;
 import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.chat.Capability;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ResponseFormat;
 import dev.langchain4j.model.ollama.OllamaChatModel;
 import dev.langchain4j.service.AiServices;
@@ -22,7 +22,7 @@ public class OllamaSuggestionService implements IAISuggestionService {
 
     private final AIConfigManager aiConfigManager = AIConfigManager.getInstance();
 
-    private ChatLanguageModel model;
+    private ChatModel model;
     private IRenameAssistant assistant;
     
     public OllamaSuggestionService() {
@@ -60,7 +60,7 @@ public class OllamaSuggestionService implements IAISuggestionService {
     
     private void initialiseRenameAssistant() {
         assistant = AiServices.builder(IRenameAssistant.class)
-                .chatLanguageModel(model)
+                .chatModel(model)
                 .systemMessageProvider(message -> aiConfigManager.getSystemMessage())
                 // TODO: use chat memory provider
                 .chatMemory(MessageWindowChatMemory.withMaxMessages(10))


### PR DESCRIPTION
This pull request updates the version for `langchain4j` dependency because of a vulnerability in transitive dependency org.apache.poi:poi-ooxml 5.3.0. Dependabot message: [https://github.com/koen-mulder/file-rename-helper/security/dependabot/3](https://github.com/koen-mulder/file-rename-helper/security/dependabot/3)
